### PR TITLE
feat: add meshery/meshery to Kubernetes section

### DIFF
--- a/awesome-list.yml
+++ b/awesome-list.yml
@@ -43,6 +43,7 @@ categories:
       description: List of kubectl plugins. You can optionally use krew to keep them up to date.
     - uri: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/
       github: kubernetes-sigs/kustomize
+      - github: meshery/meshery
 
   - name: Kubernetes Security
     items:


### PR DESCRIPTION
Added Meshery to the Kubernetes section.

Meshery is an open-source, cloud native manager for  designing and managing all Kubernetes-based 
infrastructure and applications for multi-cloud 
environments.
Resolves meshery/meshery#13426

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low functional scope (adds one list entry), but the current YAML indentation nests `meshery/meshery` under the `kustomize` item, which may break parsing/build-json or change the generated JSON structure.
> 
> **Overview**
> Adds `meshery/meshery` to the `Kubernetes` category in `awesome-list.yml`.
> 
> Note: the new entry is currently indented as a child of the `kubernetes-sigs/kustomize` item rather than a peer `items` entry, which may alter the YAML structure or fail list-to-JSON generation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a3f334c943e754c6a2de276ca8ae37eb088cd04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->